### PR TITLE
In RetryListener, only throw Exception if it belongs to certain class

### DIFF
--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -27,6 +27,7 @@ import org.apache.lucene.util.IOUtils;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.action.admin.cluster.node.liveness.LivenessRequest;
 import org.elasticsearch.action.admin.cluster.node.liveness.LivenessResponse;
 import org.elasticsearch.action.admin.cluster.node.liveness.TransportLivenessAction;
@@ -322,7 +323,8 @@ final class TransportClientNodesService extends AbstractComponent implements Clo
 
     public boolean isTextIQRetryExceptionClass(Exception e) {
         return e instanceof NoNodeAvailableException
-               || e instanceof NodeNotConnectedException;
+               || e instanceof NodeNotConnectedException
+               || e instanceof NoShardAvailableActionException;
     }
 
     public static class RetryListener<Response> implements ActionListener<Response> {

--- a/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/core/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -373,6 +373,9 @@ final class TransportClientNodesService extends AbstractComponent implements Clo
         }
 
         final DiscoveryNode getNode(int i) {
+            if (nodes.size() == 0) {
+                throw new NoNodeAvailableException("No Node in TransportClientNodeService");
+            }
             return nodes.get((index + i) % nodes.size());
         }
 


### PR DESCRIPTION
It was done for all sort of RuntimeException which includes certain Elasticsearch failure related to Type Mismatch. Update it so that we only care about failure related to the running status of ES.

In the meantime, restore the old code for `maybeNodeFailed` since this helps over explicitly disconnecting a failed Node.

In the meantime, add another place where `NoNodeAvailableException` can be thrown